### PR TITLE
Fix doc typo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ Welcome to the official support site for TrackMate. Here you’ll find answers t
    - Tap **Interactions** → **+ New Interaction**.  
    - Enter the person's or group's name.
    - Select the type of interaction you had with them.
-   - Write a note about the interaction that you might want to remnember.
+   - Write a note about the interaction that you might want to remember.
    - Select emotion tags that resonate with how you felt during the interaction.
    - Answer the three reflective questions about the interaction.  
    - Save to add it to your interaction history.


### PR DESCRIPTION
## Summary
- fix a typo in interaction guidance in docs

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68882b7f2ff8832abc02ef652877d2a7