### PR TITLE
Fix optional timestamp

### DIFF
--- a/TrackMate/ContentView.swift
+++ b/TrackMate/ContentView.swift
@@ -21,9 +21,9 @@ struct ContentView: View {
             List {
                 ForEach(items) { item in
                     NavigationLink {
-                        Text("Item at \(item.timestamp!, formatter: itemFormatter)")
+                        Text("Item at \(item.timestamp ?? Date(), formatter: itemFormatter)")
                     } label: {
-                        Text(item.timestamp!, formatter: itemFormatter)
+                        Text(item.timestamp ?? Date(), formatter: itemFormatter)
                     }
                 }
                 .onDelete(perform: deleteItems)


### PR DESCRIPTION
## Summary
- avoid force unwrapping `timestamp` in `ContentView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68882b815e14832a849f13d148cbb8ba