### PR TITLE
Fix potential crash with nil timestamp

### DIFF
--- a/TrackMate/ContentView.swift
+++ b/TrackMate/ContentView.swift
@@ -21,9 +21,17 @@ struct ContentView: View {
             List {
                 ForEach(items) { item in
                     NavigationLink {
-                        Text("Item at \(item.timestamp!, formatter: itemFormatter)")
+                        if let timestamp = item.timestamp {
+                            Text("Item at \(timestamp, formatter: itemFormatter)")
+                        } else {
+                            Text("Item at unknown date")
+                        }
                     } label: {
-                        Text(item.timestamp!, formatter: itemFormatter)
+                        if let timestamp = item.timestamp {
+                            Text(timestamp, formatter: itemFormatter)
+                        } else {
+                            Text("Unknown date")
+                        }
                     }
                 }
                 .onDelete(perform: deleteItems)


### PR DESCRIPTION
## Summary
- avoid force-unwrapping `Item.timestamp` in `ContentView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68882aa78080832a8f7ad72cd3f7f050